### PR TITLE
Add an AcidicJob::Run.purge method

### DIFF
--- a/lib/acidic_job/run.rb
+++ b/lib/acidic_job/run.rb
@@ -35,6 +35,19 @@ module AcidicJob
       validates :workflow, presence: true
     end
 
+    def self.purge
+      successfully_completed = where(
+        recovery_point: FINISHED_RECOVERY_POINT,
+        error_object: nil
+      )
+      count = successfully_completed.count
+
+      return 0 if count.zero?
+
+      Rails.logger.info("Deleting #{count} successfully completed AcidicJob runs")
+      successfully_completed.delete_all
+    end
+
     def finished?
       recovery_point == FINISHED_RECOVERY_POINT
     end

--- a/test/acidic_job/run_test.rb
+++ b/test/acidic_job/run_test.rb
@@ -152,7 +152,7 @@ class TestAcidicJobRun < Minitest::Test
       workflow: { a: "a" }
     }
     finished = AcidicJob::Run::FINISHED_RECOVERY_POINT
-  
+
     AcidicJob::Run.create!(default_attributes.merge(recovery_point: :started, error_object: nil,
                                                     idempotency_key: rand))
     AcidicJob::Run.create!(default_attributes.merge(recovery_point: :started, error_object: "T",
@@ -161,7 +161,7 @@ class TestAcidicJobRun < Minitest::Test
                                                     idempotency_key: rand))
     AcidicJob::Run.create!(default_attributes.merge(recovery_point: finished, error_object: "T",
                                                     idempotency_key: rand))
-  
+
     assert_equal 4, AcidicJob::Run.count
     assert_equal 0, AcidicJob::Run.where(recovery_point: :started).purge
   end

--- a/test/acidic_job/run_test.rb
+++ b/test/acidic_job/run_test.rb
@@ -117,4 +117,52 @@ class TestAcidicJobRun < Minitest::Test
       end
     end
   end
+
+  def test_purging_successfully_completed_runs_without_relation
+    default_attributes = {
+      staged: false,
+      job_class: MyJob,
+      serialized_job: { "job_class" => "MyJob", "job_id" => nil },
+      last_run_at: Time.now,
+      recovery_point: "a",
+      workflow: { a: "a" }
+    }
+    finished = AcidicJob::Run::FINISHED_RECOVERY_POINT
+
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: :started, error_object: nil,
+                                                    idempotency_key: rand))
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: :started, error_object: "T",
+                                                    idempotency_key: rand))
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: finished, error_object: nil,
+                                                    idempotency_key: rand))
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: finished, error_object: "T",
+                                                    idempotency_key: rand))
+
+    assert_equal 4, AcidicJob::Run.count
+    assert_equal 1, AcidicJob::Run.purge
+  end
+
+  def test_purging_successfully_completed_runs_with_relation
+    default_attributes = {
+      staged: false,
+      job_class: MyJob,
+      serialized_job: { "job_class" => "MyJob", "job_id" => nil },
+      last_run_at: Time.now,
+      recovery_point: "a",
+      workflow: { a: "a" }
+    }
+    finished = AcidicJob::Run::FINISHED_RECOVERY_POINT
+  
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: :started, error_object: nil,
+                                                    idempotency_key: rand))
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: :started, error_object: "T",
+                                                    idempotency_key: rand))
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: finished, error_object: nil,
+                                                    idempotency_key: rand))
+    AcidicJob::Run.create!(default_attributes.merge(recovery_point: finished, error_object: "T",
+                                                    idempotency_key: rand))
+  
+    assert_equal 4, AcidicJob::Run.count
+    assert_equal 0, AcidicJob::Run.where(recovery_point: :started).purge
+  end
 end


### PR DESCRIPTION
Will delete all successfully completed runs, and can accept a relation as the caller