### PR TITLE
DatabaseCleaner configuration for TestCase

### DIFF
--- a/lib/acidic_job/test_case.rb
+++ b/lib/acidic_job/test_case.rb
@@ -5,7 +5,7 @@ require "database_cleaner/active_record"
 
 module AcidicJob
   class TestCase < ActiveJob::TestCase
-    self.use_transactional_tests = false if self.respond_to?(:use_transactional_tests)
+    self.use_transactional_tests = false if respond_to?(:use_transactional_tests)
 
     def before_setup
       @original_cleaners = DatabaseCleaner.cleaners
@@ -43,7 +43,7 @@ module AcidicJob
         .strategy           # <DatabaseCleaner::ActiveRecord::Truncation>
         .class              # DatabaseCleaner::ActiveRecord::Truncation
         .name               # "DatabaseCleaner::ActiveRecord::Truncation"
-        .rpartition('::')   # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
+        .rpartition("::")   # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
         .last               # "Truncation"
         .downcase           # "truncation"
     end
@@ -51,19 +51,19 @@ module AcidicJob
     def deletion_strategy_for(cleaner)
       strategy = cleaner.strategy
       strategy_namespace = strategy # <DatabaseCleaner::ActiveRecord::Truncation>
-        .class                      # DatabaseCleaner::ActiveRecord::Truncation
-        .name                       # "DatabaseCleaner::ActiveRecord::Truncation"
-        .rpartition('::')           # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
-        .first                      # "DatabaseCleaner::ActiveRecord"
+                           .class                      # DatabaseCleaner::ActiveRecord::Truncation
+                           .name                       # "DatabaseCleaner::ActiveRecord::Truncation"
+                           .rpartition("::")           # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
+                           .first                      # "DatabaseCleaner::ActiveRecord"
       deletion_strategy_class_name = [strategy_namespace, "::", "Deletion"].join
       deletion_strategy_class = deletion_strategy_class_name.constantize
       instance_variable_hash = strategy.instance_variables.map do |var|
         [
-          var.to_s.remove('@'), 
+          var.to_s.remove("@"),
           strategy.instance_variable_get(var)
         ]
       end.to_h
-      options = instance_variable_hash.except('db', 'connection_class')
+      options = instance_variable_hash.except("db", "connection_class")
 
       deletion_strategy_class.new(**options)
     end

--- a/lib/acidic_job/test_case.rb
+++ b/lib/acidic_job/test_case.rb
@@ -5,9 +5,11 @@ require "database_cleaner/active_record"
 
 module AcidicJob
   class TestCase < ActiveJob::TestCase
-    self.use_transactional_tests = false
+    self.use_transactional_tests = false if self.respond_to?(:use_transactional_tests)
 
     def before_setup
+      @original_cleaners = DatabaseCleaner.cleaners
+      DatabaseCleaner.cleaners = transaction_free_cleaners_for(@original_cleaners)
       super
       DatabaseCleaner.start
     end
@@ -15,6 +17,55 @@ module AcidicJob
     def after_teardown
       DatabaseCleaner.clean
       super
+      DatabaseCleaner.cleaners = @original_cleaners
+    end
+
+    private
+
+    # Ensure that the system's original DatabaseCleaner configuration is maintained, options included,
+    # except that any `transaction` strategies for any ORMs are replaced with a `deletion` strategy.
+    def transaction_free_cleaners_for(original_cleaners)
+      non_transaction_cleaners = original_cleaners.dup.map do |(orm, opts), cleaner|
+        [[orm, opts], ensure_no_transaction_strategies_for(cleaner)]
+      end.to_h
+      DatabaseCleaner::Cleaners.new(non_transaction_cleaners)
+    end
+
+    def ensure_no_transaction_strategies_for(cleaner)
+      return cleaner unless strategy_name_for(cleaner) == "transaction"
+
+      cleaner.strategy = deletion_strategy_for(cleaner)
+      cleaner
+    end
+
+    def strategy_name_for(cleaner)
+      cleaner               # <DatabaseCleaner::Cleaner>
+        .strategy           # <DatabaseCleaner::ActiveRecord::Truncation>
+        .class              # DatabaseCleaner::ActiveRecord::Truncation
+        .name               # "DatabaseCleaner::ActiveRecord::Truncation"
+        .rpartition('::')   # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
+        .last               # "Truncation"
+        .downcase           # "truncation"
+    end
+
+    def deletion_strategy_for(cleaner)
+      strategy = cleaner.strategy
+      strategy_namespace = strategy # <DatabaseCleaner::ActiveRecord::Truncation>
+        .class                      # DatabaseCleaner::ActiveRecord::Truncation
+        .name                       # "DatabaseCleaner::ActiveRecord::Truncation"
+        .rpartition('::')           # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
+        .first                      # "DatabaseCleaner::ActiveRecord"
+      deletion_strategy_class_name = [strategy_namespace, "::", "Deletion"].join
+      deletion_strategy_class = deletion_strategy_class_name.constantize
+      instance_variable_hash = strategy.instance_variables.map do |var|
+        [
+          var.to_s.remove('@'), 
+          strategy.instance_variable_get(var)
+        ]
+      end.to_h
+      options = instance_variable_hash.except('db', 'connection_class')
+
+      deletion_strategy_class.new(**options)
     end
   end
 end

--- a/lib/acidic_job/test_case.rb
+++ b/lib/acidic_job/test_case.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "active_job/test_case"
-require "database_cleaner/active_record"
+require "database_cleaner"
 
 module AcidicJob
   class TestCase < ActiveJob::TestCase

--- a/test/acidic_job/extensions/action_mailer_test.rb
+++ b/test/acidic_job/extensions/action_mailer_test.rb
@@ -13,7 +13,7 @@ end
 
 class TestActionMailerExtension < Minitest::Test
   def setup
-    @user = User.find_by(stripe_customer_id: "tok_visa")
+    @user = User.find_or_create_by(email: "user@example.com", stripe_customer_id: "tok_visa")
   end
 
   def before_setup

--- a/test/acidic_job/extensions/noticed_test.rb
+++ b/test/acidic_job/extensions/noticed_test.rb
@@ -17,7 +17,7 @@ end
 
 class TestNoticedExtension < Minitest::Test
   def setup
-    @user = User.find_by(stripe_customer_id: "tok_visa")
+    @user = User.find_or_create_by(email: "user@example.com", stripe_customer_id: "tok_visa")
   end
 
   def before_setup

--- a/test/acidic_job_test.rb
+++ b/test/acidic_job_test.rb
@@ -15,7 +15,8 @@ class TestAcidicJobs < AcidicJob::TestCase
       "target_lon" => 0.0
     }.freeze
     @valid_user = User.find_or_create_by(email: "user@example.com", stripe_customer_id: "tok_visa")
-    @invalid_user = User.find_or_create_by(email: "user-bad-source@example.com", stripe_customer_id: "tok_chargeCustomerFail")
+    @invalid_user = User.find_or_create_by(email: "user-bad-source@example.com",
+                                           stripe_customer_id: "tok_chargeCustomerFail")
     @staged_job_params = { amount: 20_00, currency: "usd", user: @valid_user }
   end
 

--- a/test/acidic_job_test.rb
+++ b/test/acidic_job_test.rb
@@ -2,8 +2,9 @@
 
 require "test_helper"
 require_relative "support/ride_create_job"
+require "acidic_job/test_case"
 
-class TestAcidicJobs < Minitest::Test
+class TestAcidicJobs < AcidicJob::TestCase
   include ActiveJob::TestHelper
 
   def setup
@@ -13,8 +14,8 @@ class TestAcidicJobs < Minitest::Test
       "target_lat" => 0.0,
       "target_lon" => 0.0
     }.freeze
-    @valid_user = User.find_by(stripe_customer_id: "tok_visa")
-    @invalid_user = User.find_by(stripe_customer_id: "tok_chargeCustomerFail")
+    @valid_user = User.find_or_create_by(email: "user@example.com", stripe_customer_id: "tok_visa")
+    @invalid_user = User.find_or_create_by(email: "user-bad-source@example.com", stripe_customer_id: "tok_chargeCustomerFail")
     @staged_job_params = { amount: 20_00, currency: "usd", user: @valid_user }
   end
 

--- a/test/acidic_job_test.rb
+++ b/test/acidic_job_test.rb
@@ -20,16 +20,6 @@ class TestAcidicJobs < AcidicJob::TestCase
     @staged_job_params = { amount: 20_00, currency: "usd", user: @valid_user }
   end
 
-  def before_setup
-    super
-    DatabaseCleaner.start
-  end
-
-  def after_teardown
-    DatabaseCleaner.clean
-    super
-  end
-
   def create_run(params = {})
     AcidicJob::Run.create!({
       idempotency_key: "XXXX_IDEMPOTENCY_KEY",

--- a/test/acidic_worker_test.rb
+++ b/test/acidic_worker_test.rb
@@ -14,7 +14,8 @@ class TestAcidicWorkers < Minitest::Test
       "target_lon" => 0.0
     }.freeze
     @valid_user = User.find_or_create_by(email: "user@example.com", stripe_customer_id: "tok_visa")
-    @invalid_user = User.find_or_create_by(email: "user-bad-source@example.com", stripe_customer_id: "tok_chargeCustomerFail")
+    @invalid_user = User.find_or_create_by(email: "user-bad-source@example.com",
+                                           stripe_customer_id: "tok_chargeCustomerFail")
     @staged_job_params = [{ amount: 20_00, currency: "usd", user_id: @valid_user.id }.stringify_keys]
     @sidekiq_queue = Sidekiq::Queues["default"]
   end

--- a/test/acidic_worker_test.rb
+++ b/test/acidic_worker_test.rb
@@ -13,8 +13,8 @@ class TestAcidicWorkers < Minitest::Test
       "target_lat" => 0.0,
       "target_lon" => 0.0
     }.freeze
-    @valid_user = User.find_by(stripe_customer_id: "tok_visa")
-    @invalid_user = User.find_by(stripe_customer_id: "tok_chargeCustomerFail")
+    @valid_user = User.find_or_create_by(email: "user@example.com", stripe_customer_id: "tok_visa")
+    @invalid_user = User.find_or_create_by(email: "user-bad-source@example.com", stripe_customer_id: "tok_chargeCustomerFail")
     @staged_job_params = [{ amount: 20_00, currency: "usd", user_id: @valid_user.id }.stringify_keys]
     @sidekiq_queue = Sidekiq::Queues["default"]
   end

--- a/test/acidic_worker_test.rb
+++ b/test/acidic_worker_test.rb
@@ -4,8 +4,9 @@ require "test_helper"
 require "sidekiq"
 require "sidekiq/testing"
 require_relative "support/ride_create_worker"
+require "acidic_job/test_case"
 
-class TestAcidicWorkers < Minitest::Test
+class TestAcidicWorkers < AcidicJob::TestCase
   def setup
     @valid_params = {
       "origin_lat" => 0.0,
@@ -22,13 +23,11 @@ class TestAcidicWorkers < Minitest::Test
 
   def before_setup
     super
-    DatabaseCleaner.start
     Sidekiq::Queues.clear_all
   end
 
   def after_teardown
     Sidekiq::Queues.clear_all
-    DatabaseCleaner.clean
     super
   end
 

--- a/test/edge_cases_test.rb
+++ b/test/edge_cases_test.rb
@@ -3,6 +3,7 @@
 require "test_helper"
 require "sidekiq"
 require "sidekiq/testing"
+require "acidic_job/test_case"
 
 class CustomErrorForTesting < StandardError; end
 
@@ -69,16 +70,14 @@ class WorkerWithOldSyntax
   end
 end
 
-class TestEdgeCases < Minitest::Test
+class TestEdgeCases < AcidicJob::TestCase
   def before_setup
     super
-    DatabaseCleaner.start
     Sidekiq::Queues.clear_all
   end
 
   def after_teardown
     Sidekiq::Queues.clear_all
-    DatabaseCleaner.clean
     super
   end
 

--- a/test/support/setup.rb
+++ b/test/support/setup.rb
@@ -108,7 +108,6 @@ class Notification < ApplicationRecord
   include Noticed::Model
 end
 
-require "database_cleaner/active_record"
 DatabaseCleaner.strategy = [:deletion, { except: %w[users] }]
 DatabaseCleaner.clean
 

--- a/test/workflow_test.rb
+++ b/test/workflow_test.rb
@@ -3,6 +3,7 @@
 require "test_helper"
 require "sidekiq"
 require_relative "./support/sidekiq_batches"
+require "acidic_job/test_case"
 
 class CustomErrorForTesting < StandardError; end
 
@@ -28,20 +29,18 @@ class WorkerWithEnqueueStep < Support::Sidekiq::Workflow
   end
 end
 
-class TestWorkflows < Minitest::Test
+class TestWorkflows < AcidicJob::TestCase
   def setup
     @sidekiq_queue = Sidekiq::Queues["default"]
   end
 
   def before_setup
     super
-    DatabaseCleaner.start
     Sidekiq::Queues.clear_all
   end
 
   def after_teardown
     Sidekiq::Queues.clear_all
-    DatabaseCleaner.clean
     super
   end
 


### PR DESCRIPTION
The short version is that we store whatever the system DatabaseCleaner configuration is at the start of before_setup in an instance variable and then restore that configuration at the end of after_teardown. In between, we run the configuration thru a pipeline that selectively replaces any transaction strategies with a corresponding deletion strategy, leaving any other configured strategies untouched.