### PR TITLE
Don’t wrap the entire job in a Sidekiq::Batch, only the individual steps

### DIFF
--- a/lib/acidic_job/awaiting.rb
+++ b/lib/acidic_job/awaiting.rb
@@ -6,47 +6,32 @@ module AcidicJob
   module Awaiting
     extend ActiveSupport::Concern
 
-    class_methods do
-      # TODO: Allow the `perform` method to be used to kick off Sidekiq Batch powered workflows
-      def initiate(*args)
-        raise SidekiqBatchRequired unless defined?(Sidekiq::Batch)
-
-        top_level_workflow = Sidekiq::Batch.new
-        top_level_workflow.on(:success, self, *args)
-        top_level_workflow.jobs do
-          perform_async
-        end
-      end
-    end
-
     def enqueue_step_parallel_jobs(jobs, run, step_result)
       # `batch` is available from Sidekiq::Pro
       raise SidekiqBatchRequired unless defined?(Sidekiq::Batch)
 
-      batch.jobs do
-        step_batch = Sidekiq::Batch.new
-        # step_batch.description = "AcidicJob::Workflow Step: #{step}"
-        step_batch.on(
-          :success,
-          "#{self.class.name}#step_done",
-          # NOTE: options are marshalled through JSON so use only basic types.
-          { "run_id" => run.id,
-            "step_result_yaml" => step_result.to_yaml.strip }
-        )
-        # NOTE: The jobs method is atomic.
-        # All jobs created in the block are actually pushed atomically at the end of the block.
-        # If an error is raised, none of the jobs will go to Redis.
-        step_batch.jobs do
-          jobs.each do |worker_name|
-            # TODO: handle Symbols as well
-            worker = worker_name.is_a?(String) ? worker_name.constantize : worker_name
-            if worker.instance_method(:perform).arity.zero?
-              worker.perform_async
-            elsif worker.instance_method(:perform).arity == 1
-              worker.perform_async(run.id)
-            else
-              raise TooManyParametersForParallelJob
-            end
+      step_batch = Sidekiq::Batch.new
+      # step_batch.description = "AcidicJob::Workflow Step: #{step}"
+      step_batch.on(
+        :success,
+        "#{self.class.name}#step_done",
+        # NOTE: options are marshalled through JSON so use only basic types.
+        { "run_id" => run.id,
+          "step_result_yaml" => step_result.to_yaml.strip }
+      )
+      # NOTE: The jobs method is atomic.
+      # All jobs created in the block are actually pushed atomically at the end of the block.
+      # If an error is raised, none of the jobs will go to Redis.
+      step_batch.jobs do
+        jobs.each do |worker_name|
+          # TODO: handle Symbols as well
+          worker = worker_name.is_a?(String) ? worker_name.constantize : worker_name
+          if worker.instance_method(:perform).arity.zero?
+            worker.perform_async
+          elsif worker.instance_method(:perform).arity == 1
+            worker.perform_async(run.id)
+          else
+            raise TooManyParametersForParallelJob
           end
         end
       end

--- a/test/workflow_test.rb
+++ b/test/workflow_test.rb
@@ -64,7 +64,7 @@ class TestWorkflows < AcidicJob::TestCase
   def test_step_with_enqueues_is_run_properly
     mocking_sidekiq_batches do
       assert_raises CustomErrorForTesting do
-        WorkerWithEnqueueStep.initiate
+        WorkerWithEnqueueStep.new.perform
       end
     end
 


### PR DESCRIPTION
This removes need for staring batch jobs with `initiate`