### PR TITLE
Move test case code to testing module so it can be mixed in

### DIFF
--- a/lib/acidic_job/test_case.rb
+++ b/lib/acidic_job/test_case.rb
@@ -1,75 +1,9 @@
 # frozen_string_literal: true
 
-require "active_job/queue_adapters"
-require "active_job/base"
-require "active_job/test_helper"
-require "active_job/test_case"
-require "database_cleaner"
+require_relative "./testing"
 
 module AcidicJob
   class TestCase < ActiveJob::TestCase
-    self.use_transactional_tests = false if respond_to?(:use_transactional_tests)
-
-    def before_setup
-      @connection = ActiveRecord::Base.connection
-      @original_cleaners = DatabaseCleaner.cleaners
-      DatabaseCleaner.cleaners = transaction_free_cleaners_for(@original_cleaners)
-      super
-      DatabaseCleaner.start
-    end
-
-    def after_teardown
-      DatabaseCleaner.clean
-      super
-      DatabaseCleaner.cleaners = @original_cleaners
-    end
-
-    private
-
-    # Ensure that the system's original DatabaseCleaner configuration is maintained, options included,
-    # except that any `transaction` strategies for any ORMs are replaced with a `deletion` strategy.
-    def transaction_free_cleaners_for(original_cleaners)
-      non_transaction_cleaners = original_cleaners.dup.to_h do |(orm, opts), cleaner|
-        [[orm, opts], ensure_no_transaction_strategies_for(cleaner)]
-      end
-      DatabaseCleaner::Cleaners.new(non_transaction_cleaners)
-    end
-
-    def ensure_no_transaction_strategies_for(cleaner)
-      return cleaner unless strategy_name_for(cleaner) == "transaction"
-
-      cleaner.strategy = deletion_strategy_for(cleaner)
-      cleaner
-    end
-
-    def strategy_name_for(cleaner)
-      cleaner               # <DatabaseCleaner::Cleaner>
-        .strategy           # <DatabaseCleaner::ActiveRecord::Truncation>
-        .class              # DatabaseCleaner::ActiveRecord::Truncation
-        .name               # "DatabaseCleaner::ActiveRecord::Truncation"
-        .rpartition("::")   # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
-        .last               # "Truncation"
-        .downcase           # "truncation"
-    end
-
-    def deletion_strategy_for(cleaner)
-      strategy = cleaner.strategy
-      strategy_namespace = strategy # <DatabaseCleaner::ActiveRecord::Truncation>
-                           .class                      # DatabaseCleaner::ActiveRecord::Truncation
-                           .name                       # "DatabaseCleaner::ActiveRecord::Truncation"
-                           .rpartition("::")           # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
-                           .first                      # "DatabaseCleaner::ActiveRecord"
-      deletion_strategy_class_name = [strategy_namespace, "::", "Deletion"].join
-      deletion_strategy_class = deletion_strategy_class_name.constantize
-      instance_variable_hash = strategy.instance_variables.to_h do |var|
-        [
-          var.to_s.remove("@"),
-          strategy.instance_variable_get(var)
-        ]
-      end
-      options = instance_variable_hash.except("db", "connection_class")
-
-      deletion_strategy_class.new(**options)
-    end
+    include AcidicJob::Testing
   end
 end

--- a/lib/acidic_job/testing.rb
+++ b/lib/acidic_job/testing.rb
@@ -12,7 +12,7 @@ module AcidicJob
       mod.class_eval "self.use_transactional_tests = false if respond_to?(:use_transactional_tests)"
     end
 
-def before_setup
+    def before_setup
       @connection = ActiveRecord::Base.connection
       @original_cleaners = DatabaseCleaner.cleaners
       DatabaseCleaner.cleaners = transaction_free_cleaners_for(@original_cleaners)

--- a/lib/acidic_job/testing.rb
+++ b/lib/acidic_job/testing.rb
@@ -8,7 +8,7 @@ require "database_cleaner"
 
 module AcidicJob
   module Testing
-    def Testing.included(mod)
+    def self.included(mod)
       mod.class_eval "self.use_transactional_tests = false if respond_to?(:use_transactional_tests)"
     end
 

--- a/lib/acidic_job/testing.rb
+++ b/lib/acidic_job/testing.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "active_job/queue_adapters"
+require "active_job/base"
+require "active_job/test_helper"
+require "active_job/test_case"
+require "database_cleaner"
+
+module AcidicJob
+  module Testing
+    def Testing.included(mod)
+      mod.class_eval "self.use_transactional_tests = false if respond_to?(:use_transactional_tests)"
+    end
+
+def before_setup
+      @connection = ActiveRecord::Base.connection
+      @original_cleaners = DatabaseCleaner.cleaners
+      DatabaseCleaner.cleaners = transaction_free_cleaners_for(@original_cleaners)
+      super
+      DatabaseCleaner.start
+    end
+
+    def after_teardown
+      DatabaseCleaner.clean
+      super
+      DatabaseCleaner.cleaners = @original_cleaners
+    end
+
+    private
+
+    # Ensure that the system's original DatabaseCleaner configuration is maintained, options included,
+    # except that any `transaction` strategies for any ORMs are replaced with a `deletion` strategy.
+    def transaction_free_cleaners_for(original_cleaners)
+      non_transaction_cleaners = original_cleaners.dup.to_h do |(orm, opts), cleaner|
+        [[orm, opts], ensure_no_transaction_strategies_for(cleaner)]
+      end
+      DatabaseCleaner::Cleaners.new(non_transaction_cleaners)
+    end
+
+    def ensure_no_transaction_strategies_for(cleaner)
+      return cleaner unless strategy_name_for(cleaner) == "transaction"
+
+      cleaner.strategy = deletion_strategy_for(cleaner)
+      cleaner
+    end
+
+    def strategy_name_for(cleaner)
+      cleaner               # <DatabaseCleaner::Cleaner>
+        .strategy           # <DatabaseCleaner::ActiveRecord::Truncation>
+        .class              # DatabaseCleaner::ActiveRecord::Truncation
+        .name               # "DatabaseCleaner::ActiveRecord::Truncation"
+        .rpartition("::")   # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
+        .last               # "Truncation"
+        .downcase           # "truncation"
+    end
+
+    def deletion_strategy_for(cleaner)
+      strategy = cleaner.strategy
+      strategy_namespace = strategy # <DatabaseCleaner::ActiveRecord::Truncation>
+                           .class                      # DatabaseCleaner::ActiveRecord::Truncation
+                           .name                       # "DatabaseCleaner::ActiveRecord::Truncation"
+                           .rpartition("::")           # ["DatabaseCleaner::ActiveRecord", "::", "Truncation"]
+                           .first                      # "DatabaseCleaner::ActiveRecord"
+      deletion_strategy_class_name = [strategy_namespace, "::", "Deletion"].join
+      deletion_strategy_class = deletion_strategy_class_name.constantize
+      instance_variable_hash = strategy.instance_variables.to_h do |var|
+        [
+          var.to_s.remove("@"),
+          strategy.instance_variable_get(var)
+        ]
+      end
+      options = instance_variable_hash.except("db", "connection_class")
+
+      deletion_strategy_class.new(**options)
+    end
+  end
+end


### PR DESCRIPTION
This simply moves the testing setup to a module `AcidicJob::Testing`, so it can be mixed into any test.

Works fine with some if my controller tests where I called `perform_enqueued_jobs`.