### PR TITLE
Iterable Steps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
-    sidekiq (6.4.1)
+    sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)

--- a/lib/acidic_job.rb
+++ b/lib/acidic_job.rb
@@ -131,7 +131,7 @@ module AcidicJob
     return run.succeeded? if run.finished?
 
     # otherwise, we will enter a loop to process each step of the workflow
-    run.workflow.size.times do
+    loop do
       recovery_point = run.recovery_point.to_s
       current_step = run.workflow[recovery_point]
 
@@ -170,12 +170,13 @@ module AcidicJob
     run.succeeded?
   end
 
-  def step(method_name, awaits: [])
+  def step(method_name, awaits: [], for_each: nil)
     @__acidic_job_steps ||= []
 
     @__acidic_job_steps << {
       "does" => method_name.to_s,
-      "awaits" => awaits
+      "awaits" => awaits,
+      "for_each" => for_each
     }
 
     @__acidic_job_steps


### PR DESCRIPTION
Allow a step to define a collection from attr_accessors that should be iterated over and passed to the step method until fully processed

```ruby
class WorkerWithForEachStep
  include Sidekiq::Worker
  include AcidicJob

  attr_reader :processed_items

  def initialize
    @processed_items = []
    super()
  end

  def perform
    with_acidity providing: { items: (1..10).to_a } do
      step :work_with_individual_item, for_each: :items
    end
  end

  def work_with_individual_item(item)
    @processed_items << item
  end
end
```

@julianrubisch: What do you think about the semantics?