### PR TITLE
Finish callbacks

### DIFF
--- a/lib/acidic_job.rb
+++ b/lib/acidic_job.rb
@@ -48,6 +48,7 @@ module AcidicJob
     end
 
     klass.set_callback :perform, :after, :delete_staged_job_record, if: :was_staged_job?
+    klass.define_callbacks :finish
 
     klass.instance_variable_set(:@acidic_identifier, :job_id)
     klass.define_singleton_method(:acidic_by_job_id) { @acidic_identifier = :job_id }
@@ -128,7 +129,7 @@ module AcidicJob
 
   def process_run(run)
     # if the run record is already marked as finished, immediately return its result
-    return run.succeeded? if run.finished?
+    return finish_run(run) if run.finished?
 
     # otherwise, we will enter a loop to process each step of the workflow
     loop do
@@ -167,7 +168,13 @@ module AcidicJob
     end
 
     # the loop will break once the job is finished, so simply report the status
-    run.succeeded?
+    finish_run(run)
+  end
+
+  def finish_run(run)
+    run_callbacks :finish do
+      run.succeeded?
+    end
   end
 
   def step(method_name, awaits: [], for_each: nil)

--- a/lib/acidic_job.rb
+++ b/lib/acidic_job.rb
@@ -47,6 +47,7 @@ module AcidicJob
       raise UnknownJobAdapter
     end
 
+    # TODO: write test for a staged job that uses awaits
     klass.set_callback :perform, :after, :delete_staged_job_record, if: :was_staged_job?
     klass.define_callbacks :finish
 

--- a/test/support/sidekiq_batches.rb
+++ b/test/support/sidekiq_batches.rb
@@ -2,12 +2,6 @@
 
 require_relative "sidekiq_testing"
 
-module Sidekiq
-  class Batch
-    class Status; end # rubocop:disable Lint/EmptyClass
-  end
-end
-
 module Support
   module Sidekiq
     class NullObject
@@ -115,5 +109,11 @@ module Support
         end
       end
     end
+  end
+end
+
+module Sidekiq
+  class Batch < Support::Sidekiq::NullBatch
+    class Status < Support::Sidekiq::NullStatus; end
   end
 end


### PR DESCRIPTION
Since a job can have an "await step" (e.g. `step :do_something, awaits: [AnotherJob]`) it is possible for `after_perform` to not be the same as `after_finish`. Here, we add a `finish` event that users can write callbacks for (`after_finish`, `before_finish`, and `around_finish`) via the `set_callback` method from ActiveSupport (e.g. `set_callback :finish, :after, :remove_run_record`)