### PR TITLE
Ensure that `with_acidic_workflow` takes a block argument

### DIFF
--- a/lib/acidic_job/errors.rb
+++ b/lib/acidic_job/errors.rb
@@ -15,4 +15,5 @@ module AcidicJob
   class UnserializableValue < Error; end
   class LockedIdempotencyKey < Error; end
   class MismatchedIdempotencyKeyAndJobArguments < Error; end
+  class MissingBlockArgument < Error; end
 end

--- a/lib/acidic_job/mixin.rb
+++ b/lib/acidic_job/mixin.rb
@@ -81,12 +81,9 @@ module AcidicJob
       @workflow_builder = WorkflowBuilder.new
 
       raise MissingWorkflowBlock, "A block must be passed to `with_acidic_workflow`" unless block_given?
+      raise MissingBlockArgument, "An argument must be passed to the `with_acidic_workflow` block" if block.arity.zero?
 
-      if block.arity.zero?
-        @workflow_builder.instance_exec(&block)
-      else
-        yield @workflow_builder
-      end
+      block.call @workflow_builder
 
       raise NoDefinedSteps if @workflow_builder.steps.empty?
 

--- a/test/cases/active_job/edge_cases_test.rb
+++ b/test/cases/active_job/edge_cases_test.rb
@@ -28,10 +28,22 @@ module Cases
         end
       end
 
-      test "calling `with_acidic_workflow` with a block without steps raises `NoDefinedSteps`" do
+      test "calling `with_acidic_workflow` with a block without an argument raises `MissingBlockArgument`" do
         class WithoutSteps < AcidicJob::Base
           def perform
             with_acidic_workflow {} # rubocop:disable Lint/EmptyBlock
+          end
+        end
+
+        assert_raises AcidicJob::MissingBlockArgument do
+          WithoutSteps.perform_now
+        end
+      end
+
+      test "calling `with_acidic_workflow` with a block without steps raises `NoDefinedSteps`" do
+        class WithoutSteps < AcidicJob::Base
+          def perform
+            with_acidic_workflow { |_workflow| } # rubocop:disable Lint/EmptyBlock
           end
         end
 

--- a/test/cases/active_kiq/edge_cases_test.rb
+++ b/test/cases/active_kiq/edge_cases_test.rb
@@ -37,10 +37,22 @@ module Cases
         end
       end
 
-      test "calling `with_acidic_workflow` with a block without steps raises `NoDefinedSteps`" do
+      test "calling `with_acidic_workflow` with a block without an argument raises `MissingBlockArgument`" do
         class WithoutSteps < AcidicJob::ActiveKiq
           def perform
             with_acidic_workflow {} # rubocop:disable Lint/EmptyBlock
+          end
+        end
+
+        assert_raises AcidicJob::MissingBlockArgument do
+          WithoutSteps.perform_now
+        end
+      end
+
+      test "calling `with_acidic_workflow` with a block without steps raises `NoDefinedSteps`" do
+        class WithoutSteps < AcidicJob::ActiveKiq
+          def perform
+            with_acidic_workflow { |_workflow| } # rubocop:disable Lint/EmptyBlock
           end
         end
 


### PR DESCRIPTION
To ensure that it is a closure and the `step` methods have access to variables defined in the `perform` scope