### PR TITLE
Ensure that awaiting is resilient

### DIFF
--- a/lib/acidic_job/run.rb
+++ b/lib/acidic_job/run.rb
@@ -173,6 +173,10 @@ module AcidicJob
         current_step_hash.fetch("then")
       end
 
+      def current_step_awaits
+        current_step_hash.fetch("awaits", []) || []
+      end
+
       def next_step_finishes?
         next_step_name.to_s == FINISHED_RECOVERY_POINT
       end


### PR DESCRIPTION
So, passing `nil`, `[nil]`, or a method that returns either `nil` or `[nil]` is handled correctly (ignored)