### PR TITLE
Update README.md to make Persisted Attributes example more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ class RideCreateJob < AcidicJob::Base
   end
 
   def create_ride_and_audit_record
-    self.ride = Ride.create!
+    self.ride = @user.rides.create(@params)
   end
 
   def create_stripe_charge


### PR DESCRIPTION
I was reading through the README and noticed that the example for Persisted Attributes confused me a bit.

In `create_ride_and_audit_record` you do a simple `Ride.create!` and in `create_stripe_charge` you reference `@ride.user`, so I felt it should assign that user somewhere. Since the `@user` and `@params` instance variables are also in the example I think it makes sense to use them and have a more complete example.

What do you think?  

One alternative I considered was `Ride.create!(user: user, **@params)` but I think it's less pretty.