### PR TITLE
fix: Ensure Ruby 3.2.0 keyword params compatibility

### DIFF
--- a/lib/acidic_job/perform_wrapper.rb
+++ b/lib/acidic_job/perform_wrapper.rb
@@ -4,7 +4,7 @@ module AcidicJob
   # NOTE: it is essential that this be a bare module and not an ActiveSupport::Concern
   # WHY?
   module PerformWrapper
-    def perform(*args)
+    ruby2_keywords def perform(*args)
       @arguments = args
 
       # we don't want to run the `perform` callbacks twice, since ActiveJob already handles that for us


### PR DESCRIPTION
See https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/