### PR TITLE
Update exception_serializer.rb

### DIFF
--- a/lib/acidic_job/active_kiq.rb
+++ b/lib/acidic_job/active_kiq.rb
@@ -126,16 +126,16 @@ module AcidicJob
     # https://github.com/rails/rails/blob/93c9534c9871d4adad4bc33b5edc355672b59c61/activejob/lib/active_job/callbacks.rb
     concerning :Callbacks do
       class_methods do
-        def around_perform(*filters, &blk)
-          set_callback(:perform, :around, *filters, &blk)
+        def around_perform(...)
+          set_callback(:perform, :around, ...)
         end
 
-        def before_perform(*filters, &blk)
-          set_callback(:perform, :before, *filters, &blk)
+        def before_perform(...)
+          set_callback(:perform, :before, ...)
         end
 
-        def after_perform(*filters, &blk)
-          set_callback(:perform, :after, *filters, &blk)
+        def after_perform(...)
+          set_callback(:perform, :after, ...)
         end
       end
     end

--- a/lib/acidic_job/active_kiq.rb
+++ b/lib/acidic_job/active_kiq.rb
@@ -85,7 +85,7 @@ module AcidicJob
           "jid" => @job_id,
           "queue" => @queue_name
         }
-        item["at"] = @scheduled_at if @scheduled_at
+        item["at"] = @scheduled_at if defined?(@scheduled_at) && @scheduled_at
 
         ::Sidekiq::Client.push(item)
       end

--- a/lib/acidic_job/run.rb
+++ b/lib/acidic_job/run.rb
@@ -15,7 +15,7 @@ module AcidicJob
     STAGED_JOB_ID_PREFIX = "STG"
     STAGED_JOB_ID_DELIMITER = "__"
     IDEMPOTENCY_KEY_LOCK_TIMEOUT_SECONDS = 2
-    RAILS_VERSION = Gem::Version.new(Rails.version)
+    RAILS_VERSION = Gem::Version.new(ActiveRecord.version)
     TARGET_VERSION = Gem::Version.new("7.1")
     REQUIRES_CODER_FOR_SERIALIZE = RAILS_VERSION >= TARGET_VERSION ||
                                    RAILS_VERSION.segments[..1] == TARGET_VERSION.segments

--- a/lib/acidic_job/serializers/exception_serializer.rb
+++ b/lib/acidic_job/serializers/exception_serializer.rb
@@ -7,7 +7,7 @@ module AcidicJob
     class ExceptionSerializer < ::ActiveJob::Serializers::ObjectSerializer
       def serialize(exception)
         compressed_backtrace = {}
-        exception.backtrace.map do |trace|
+        exception.backtrace&.map do |trace|
           path, _, location = trace.rpartition("/")
           next if compressed_backtrace.key?(path)
           compressed_backtrace[path] = location

--- a/lib/acidic_job/serializers/exception_serializer.rb
+++ b/lib/acidic_job/serializers/exception_serializer.rb
@@ -17,11 +17,11 @@ module AcidicJob
         end)
         exception.cause&.set_backtrace([])
 
-        super(exception.to_yaml)
+        super({'yaml' => exception.to_yaml})
       end
 
-      def deserialize(yaml)
-        exception = YAML.unsafe_load(yaml)
+      def deserialize(hash)
+        exception = YAML.unsafe_load(hash['yaml'])
         
         exception
       end

--- a/lib/acidic_job/serializers/exception_serializer.rb
+++ b/lib/acidic_job/serializers/exception_serializer.rb
@@ -22,7 +22,11 @@ module AcidicJob
       end
 
       def deserialize(hash)
-        YAML.unsafe_load(hash["yaml"])
+        if YAML.respond_to?(:unsafe_load)
+          YAML.unsafe_load(hash["yaml"])
+        else
+          YAML.load(hash["yaml"]) # rubocop:disable Security/YAMLLoad
+        end
       end
 
       def serialize?(argument)

--- a/lib/acidic_job/serializers/exception_serializer.rb
+++ b/lib/acidic_job/serializers/exception_serializer.rb
@@ -10,6 +10,7 @@ module AcidicJob
         exception.backtrace&.map do |trace|
           path, _, location = trace.rpartition("/")
           next if compressed_backtrace.key?(path)
+
           compressed_backtrace[path] = location
         end
         exception.set_backtrace(compressed_backtrace.map do |path, location|
@@ -17,13 +18,11 @@ module AcidicJob
         end)
         exception.cause&.set_backtrace([])
 
-        super({'yaml' => exception.to_yaml})
+        super({ "yaml" => exception.to_yaml })
       end
 
       def deserialize(hash)
-        exception = YAML.unsafe_load(hash['yaml'])
-        
-        exception
+        YAML.unsafe_load(hash["yaml"])
       end
 
       def serialize?(argument)

--- a/lib/acidic_job/serializers/exception_serializer.rb
+++ b/lib/acidic_job/serializers/exception_serializer.rb
@@ -22,10 +22,19 @@ module AcidicJob
       end
 
       def deserialize(hash)
-        if YAML.respond_to?(:unsafe_load)
-          YAML.unsafe_load(hash["yaml"])
-        else
-          YAML.load(hash["yaml"]) # rubocop:disable Security/YAMLLoad
+        if hash.key?("class")
+          exception_class = hash["class"].constantize
+          exception = exception_class.new(hash["message"])
+          exception.set_backtrace(hash["backtrace"].map do |path, location|
+                                    [path, location].join("/")
+                                  end)
+          exception
+        elsif hash.key?("yaml")
+          if YAML.respond_to?(:unsafe_load)
+            YAML.unsafe_load(hash["yaml"])
+          else
+            YAML.load(hash["yaml"]) # rubocop:disable Security/YAMLLoad
+          end
         end
       end
 

--- a/test/acidic_job/run_test.rb
+++ b/test/acidic_job/run_test.rb
@@ -81,7 +81,7 @@ class TestAcidicJobRun < ActiveSupport::TestCase
   end
 
   def test_enqueue_staged_job_only_runs_for_staged_jobs
-    job_mock = MiniTest::Mock.new
+    job_mock = Minitest::Mock.new
     job_mock.expect :enqueue, true
 
     MyJob.stub :deserialize, job_mock do

--- a/test/acidic_job/serializer_test.rb
+++ b/test/acidic_job/serializer_test.rb
@@ -323,8 +323,7 @@ class TestAcidicJobSerializer < ActiveSupport::TestCase
         job_class: "TestAcidicJobSerializer::RandomActiveKiqWithExceptionArg",
         arguments: [
           { _aj_serialized: "AcidicJob::Serializers::ExceptionSerializer",
-            yaml: exception.to_yaml
-          }
+            yaml: exception.to_yaml }
         ] }.to_json,
       AcidicJob::Serializer.dump(instance)
     )

--- a/test/acidic_job/serializer_test.rb
+++ b/test/acidic_job/serializer_test.rb
@@ -140,7 +140,9 @@ class TestAcidicJobSerializer < ActiveSupport::TestCase
 
   test "can serialize a Job instance with Exception argument" do
     class RandomJobWithExceptionArg < ActiveJob::Base; end
-    instance = RandomJobWithExceptionArg.new(StandardError.new("CUSTOM MESSAGE"))
+    exception = StandardError.new("CUSTOM MESSAGE")
+    exception.set_backtrace([])
+    instance = RandomJobWithExceptionArg.new(exception)
     instance.job_id = "12a345bc-67e8-90f1-23g4-5h6i7jk8l901"
 
     assert_equal(
@@ -151,10 +153,7 @@ class TestAcidicJobSerializer < ActiveSupport::TestCase
         queue_name: "default",
         priority: nil,
         arguments: [{ _aj_serialized: "AcidicJob::Serializers::ExceptionSerializer",
-                      class: "StandardError",
-                      message: "CUSTOM MESSAGE",
-                      cause: nil,
-                      backtrace: {} }],
+                      yaml: exception.to_yaml }],
         executions: 0,
         exception_executions: {},
         locale: "en",
@@ -314,7 +313,9 @@ class TestAcidicJobSerializer < ActiveSupport::TestCase
 
   test "can serialize an ActiveKiq instance with Exception argument" do
     class RandomActiveKiqWithExceptionArg < AcidicJob::ActiveKiq; end
-    instance = RandomActiveKiqWithExceptionArg.new(StandardError.new("CUSTOM MESSAGE"))
+    exception = StandardError.new("CUSTOM MESSAGE")
+    exception.set_backtrace([])
+    instance = RandomActiveKiqWithExceptionArg.new(exception)
     instance.job_id = "12a345bc-67e8-90f1-23g4-5h6i7jk8l901"
 
     assert_equal(
@@ -322,10 +323,8 @@ class TestAcidicJobSerializer < ActiveSupport::TestCase
         job_class: "TestAcidicJobSerializer::RandomActiveKiqWithExceptionArg",
         arguments: [
           { _aj_serialized: "AcidicJob::Serializers::ExceptionSerializer",
-            class: "StandardError",
-            message: "CUSTOM MESSAGE",
-            cause: nil,
-            backtrace: {} }
+            yaml: exception.to_yaml
+          }
         ] }.to_json,
       AcidicJob::Serializer.dump(instance)
     )

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,9 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "bundler/setup"
 require "rails/version"
+require "sidekiq/version"
 
-p({ ruby: RUBY_VERSION, rails: Rails::VERSION::STRING })
+p({ ruby: RUBY_VERSION, rails: Rails::VERSION::STRING, sidekiq: Sidekiq::VERSION })
 
 require "simplecov"
 SimpleCov.start do


### PR DESCRIPTION
Use Ruby's built in YAML serialization for exceptions, as they can have a wide range of implementations and serializing to a hash has proven error-prone.