### PR TITLE
Remove lambda from default value in migration

### DIFF
--- a/lib/generators/acidic_job/templates/create_acidic_job_runs_migration.rb.erb
+++ b/lib/generators/acidic_job/templates/create_acidic_job_runs_migration.rb.erb
@@ -1,7 +1,7 @@
 class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :acidic_job_runs do |t|
-      t.boolean     :staged, 					null: false,  default: -> { false }
+      t.boolean     :staged, 					null: false,  default: false
       t.string      :idempotency_key, null: false,  index: { unique: true }
       t.text        :serialized_job, 	null: false
       t.string      :job_class, 			null: false


### PR DESCRIPTION
This resolves an issue with the ActiveRecord SQLite adapter, which raises an error when the lambda contains values that don't respond to match?.

https://github.com/rails/rails/blob/e1d58cfd05ae1cc0bfc1006b7ce973a7730831df/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb#L89

Fixes https://github.com/fractaledmind/acidic_job/issues/95

Sorry about the noise around the multiple PRs -- was force pushing on my fork to move the change to a different branch and it permanently closed the other PR.