### PR TITLE
Remove `to_f` in `set` method to prevent error

### DIFF
--- a/lib/acidic_job/mixin.rb
+++ b/lib/acidic_job/mixin.rb
@@ -63,8 +63,8 @@ module AcidicJob
 
     # Configures the job with the given options.
     def set(options = {}) # :nodoc:
-      self.scheduled_at = options[:wait].seconds.from_now.to_f if options[:wait]
-      self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
+      self.scheduled_at = options[:wait].seconds.from_now if options[:wait]
+      self.scheduled_at = options[:wait_until] if options[:wait_until]
       self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
       self.priority     = options[:priority].to_i if options[:priority]
 


### PR DESCRIPTION
This change prevents a `NoMethodError` when retrying jobs or scheduling jobs with `set(wait: ...)` for adapters like GoodJob and Solid Queue.

Fixes #92.

I added a test to check that scheduled_at is not cast. I wasn't sure if you thought it was necessary to bring in Solid Queue or Good Job to actually test those adapters. Happy to make changes if you have other suggestions on how to test here.