### PR TITLE
Idempotency key strict json

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,4 @@
+---
+exclude_paths:
+  - "**/*.md"
+  - "LICENSE"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activejob (>= 7.1)
       activerecord (>= 7.1)
       activesupport (>= 7.1)
-      json (= 2.7.0)
+      json (>= 2.7.0)
       railties (>= 7.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.6.3)
+    json (2.10.2)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activejob (>= 7.1)
       activerecord (>= 7.1)
       activesupport (>= 7.1)
+      json (= 2.7.0)
       railties (>= 7.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ class RideCreateJob < AcidicJob::Base
 end
 ```
 
-The `unique_by` keyword argument is used to define the unique identifier for a particular execution of the workflow. This helps to ensure that the workflow is idempotent, as retries of the job will correctly resume the pre-existing workflow execution. The `unique_by` argument can be anything that `JSON.dump` can handle.
+> [!IMPORTANT]
+> The `unique_by` keyword argument is used to define the unique identifier for a particular execution of the workflow. This helps to ensure that the workflow is idempotent, as retries of the job will correctly resume the pre-existing workflow execution. The `unique_by` argument can **only** be something that `JSON.generate(..., strict: true)` can handle; that is, it must be made up of only the JSON native types: `Hash`, `Array`, `String`, `Integer`, `Float`, `true`, `false` and `nil`.
 
 The block passed to `execute_workflow` is where you define the steps of the workflow. Each step is defined by calling the `step` method on the yielded workflow builder object. The `step` method takes the name of a method in the job that will be executed as part of the workflow. The `transactional` keyword argument can be used to ensure that the step is executed within a database transaction.
 

--- a/acidic_job.gemspec
+++ b/acidic_job.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "json", ">= 2.7.0"
   ">= 7.1".tap do |rails_version|
     spec.add_dependency "activejob", rails_version
     spec.add_dependency "activerecord", rails_version

--- a/acidic_job.gemspec
+++ b/acidic_job.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "json", ">= 2.7.0"
+  spec.add_dependency "json", ">= 2.7.0" # see: https://github.com/ruby/json/pull/519
   ">= 7.1".tap do |rails_version|
     spec.add_dependency "activejob", rails_version
     spec.add_dependency "activerecord", rails_version

--- a/lib/acidic_job/workflow.rb
+++ b/lib/acidic_job/workflow.rb
@@ -38,7 +38,7 @@ module AcidicJob
                            else
                              { isolation: :serializable }
                            end
-        idempotency_key = Digest::SHA256.hexdigest(JSON.dump([self.class.name, unique_by]))
+        idempotency_key = Digest::SHA256.hexdigest(JSON.fast_generate([self.class.name, unique_by], strict: true))
 
         @execution = ::ActiveRecord::Base.transaction(**transaction_args) do
           record = Execution.find_by(idempotency_key: idempotency_key)

--- a/test/acidic_job/idempotency_key_test.rb
+++ b/test/acidic_job/idempotency_key_test.rb
@@ -19,7 +19,7 @@ class AcidicJob::IdempotencyKey < ActiveSupport::TestCase
     end
   end
 
-  test "idempotency_key when unique_by is arguments and arguments are empty" do
+  test "idempotency_key when unique_by is empty" do
     class AcidicByArguments < ActiveJob::Base
       include AcidicJob::Workflow
 
@@ -38,7 +38,7 @@ class AcidicJob::IdempotencyKey < ActiveSupport::TestCase
     assert_equal "bab619c21aa975baef217fbd5c6e01a7674d9d8ee3fa1c4e2a178e41d7952b23", execution.idempotency_key
   end
 
-  test "idempotency_key when unique_by is arguments and arguments are a static string" do
+  test "idempotency_key when unique_by is a static string" do
     class AcidicByBlockWithString < ActiveJob::Base
       include AcidicJob::Workflow
 
@@ -57,7 +57,7 @@ class AcidicJob::IdempotencyKey < ActiveSupport::TestCase
     assert_equal "11460654191869f08d979326233f4d4b1287b77ed069c53ac79036d96d54dd3e", execution.idempotency_key
   end
 
-  test "idempotency_key when unique_by is arguments and arguments are an array of strings" do
+  test "idempotency_key when unique_by is an array of strings" do
     class AcidicByBlockWithArrayOfStrings < ActiveJob::Base
       include AcidicJob::Workflow
 
@@ -76,7 +76,7 @@ class AcidicJob::IdempotencyKey < ActiveSupport::TestCase
     assert_equal "76564b0604a5dfd81d1f637416e664352eda527e2cd78a806e91ad6ccd609eb3", execution.idempotency_key
   end
 
-  test "idempotency_key when unique_by is arguments and arguments are an array of different values" do
+  test "idempotency_key when unique_by is an array of different values" do
     class AcidicByBlockWithArgValue < ActiveJob::Base
       include AcidicJob::Workflow
 
@@ -95,7 +95,7 @@ class AcidicJob::IdempotencyKey < ActiveSupport::TestCase
     assert_equal "a7c36d24b42051092df5547146952d4707bf6e04b84774576bad6a37937d018a", execution.idempotency_key
   end
 
-  test "idempotency_key when unique_by is arguments and arguments is an ActiveRecord model raises JSON::GeneratorError" do
+  test "idempotency_key when unique_by is ActiveRecord model raises JSON::GeneratorError" do
     class AcidicByBlockWithActiveRecordInstance < ActiveJob::Base
       include AcidicJob::Workflow
 


### PR DESCRIPTION
Resolves #111 

As the README says:
> The `unique_by` argument can be anything that `JSON.dump` can handle.

This, however, was not enforced by the library. Now, we enforce `strict` mode when generating JSON, throwing a `JSON::GenerationError` is any non-basic types are passed to the `unique_by` argument.

> [!NOTE]
> JSON native types: `Hash`, `Array`, `String`, `Integer`, `Float`, `true`, `false` and `nil`.