### PR TITLE
Properly scope UndefinedMethodError

### DIFF
--- a/lib/acidic_job/workflow.rb
+++ b/lib/acidic_job/workflow.rb
@@ -168,15 +168,17 @@ module AcidicJob
 
     def perform_step_for(step_definition)
       step_name = step_definition.fetch("does")
-      step_method = method(step_name)
+      begin
+        step_method = method(step_name)
+      rescue NameError
+        raise UndefinedMethodError.new(step_name)
+      end
 
       raise InvalidMethodError.new(step_name) unless step_method.arity.zero?
 
       wrapper = step_definition["transactional"] ? @execution.method(:with_lock) : NO_OP_WRAPPER
 
       catch(:repeat) { wrapper.call { step_method.call } }
-    rescue NameError
-      raise UndefinedMethodError.new(step_name)
     end
   end
 end


### PR DESCRIPTION
Only raise `UndefinedMethodError` if can't find step method. Don't rescue any `NameError` raised anywhere in `perform_step_for`, as this can lead to false positives