### PR TITLE
Minimize transactions

### DIFF
--- a/app/models/acidic_job/execution.rb
+++ b/app/models/acidic_job/execution.rb
@@ -28,12 +28,12 @@ module AcidicJob
 
     def record!(step:, action:, timestamp:, **kwargs)
       AcidicJob.instrument(:record_entry, step: step, action: action, timestamp: timestamp, data: kwargs) do
-        entries.create!(
+        entries.insert!({
           step: step,
           action: action,
           timestamp: timestamp,
-          data: kwargs.stringify_keys!
-        )
+          data: kwargs.stringify_keys!,
+        })
       end
     end
 

--- a/lib/acidic_job/workflow.rb
+++ b/lib/acidic_job/workflow.rb
@@ -105,7 +105,7 @@ module AcidicJob
               )
               return true
             else
-              @__acidic_job_execution__.update!(recover_to: recover_to)
+              @__acidic_job_execution__.update_column(:recover_to, recover_to)
             end
           end
         end


### PR DESCRIPTION
We don't need to wrap every single write in a transaction. Many can be safe and atomic direct writes. This helps reduce strain on the database