### PR TITLE
Serialization

### DIFF
--- a/app/models/acidic_job/entry.rb
+++ b/app/models/acidic_job/entry.rb
@@ -4,6 +4,8 @@ module AcidicJob
   class Entry < Record
     belongs_to :execution, class_name: "AcidicJob::Execution"
 
+    serialize :data, coder: AcidicJob::Serializer
+
     scope :for_step, -> (step) { where(step: step) }
     scope :for_action, -> (action) { where(action: action) }
     scope :ordered, -> { order(timestamp: :asc) }

--- a/app/models/acidic_job/execution.rb
+++ b/app/models/acidic_job/execution.rb
@@ -5,6 +5,8 @@ module AcidicJob
     has_many :entries, class_name: "AcidicJob::Entry", dependent: :destroy
     has_many :values, class_name: "AcidicJob::Value", dependent: :destroy
 
+    serialize :definition, coder: AcidicJob::Serializer
+
     validates :idempotency_key, presence: true # uniqueness constraint is enforced at the database level
     validates :serialized_job, presence: true
 

--- a/app/models/acidic_job/execution.rb
+++ b/app/models/acidic_job/execution.rb
@@ -34,7 +34,7 @@ module AcidicJob
           step: step,
           action: action,
           timestamp: timestamp,
-          data: kwargs.stringify_keys!,
+          data: kwargs.except(:ignored),
         })
       end
     end
@@ -46,7 +46,6 @@ module AcidicJob
     def finished?
       recover_to.to_s == FINISHED_RECOVERY_POINT ||
         recover_to.to_s == "FINISHED" # old value pre-1.0, remove at v1.0
-      # rubocop:enable Style/MultipleComparison
     end
 
     def defined?(step)

--- a/app/models/acidic_job/execution.rb
+++ b/app/models/acidic_job/execution.rb
@@ -28,7 +28,7 @@ module AcidicJob
       end
     end
 
-    def record!(step:, action:, timestamp:, **kwargs)
+    def record!(step:, action:, timestamp: Time.current, **kwargs)
       AcidicJob.instrument(:record_entry, step: step, action: action, timestamp: timestamp, data: kwargs) do
         entries.insert!({
           step: step,

--- a/lib/acidic_job/serializer.rb
+++ b/lib/acidic_job/serializer.rb
@@ -20,8 +20,9 @@ module AcidicJob
       data = Arguments.__send__ :serialize_argument, obj
 
       JSON.fast_generate data, strict: true
-    rescue ActiveJob::SerializationError
-      raise UnserializableValue
+    rescue ActiveJob::SerializationError => e
+      e.message << " (`#{obj.inspect}`)"
+      raise e
     end
   end
 end

--- a/lib/acidic_job/workflow.rb
+++ b/lib/acidic_job/workflow.rb
@@ -153,7 +153,13 @@ module AcidicJob
         when REPEAT_STEP
           curr_step
         else
-          @__acidic_job_execution__.record!(step: curr_step, action: :succeeded, timestamp: Time.now, result: result)
+          @__acidic_job_execution__.record!(
+            step: curr_step,
+            action: :succeeded,
+            ignored: {
+              result: result,
+            }
+          )
           next_step
         end
       rescue => e

--- a/lib/acidic_job/workflow.rb
+++ b/lib/acidic_job/workflow.rb
@@ -101,7 +101,6 @@ module AcidicJob
               @__acidic_job_execution__.record!(
                 step: step_definition.fetch("does"),
                 action: :halted,
-                timestamp: Time.now
               )
               return true
             else
@@ -146,7 +145,7 @@ module AcidicJob
 
       rescued_error = nil
       begin
-        @__acidic_job_execution__.record!(step: curr_step, action: :started, timestamp: Time.now)
+        @__acidic_job_execution__.record!(step: curr_step, action: :started)
         result = AcidicJob.instrument(:perform_step, **step_definition) do
           perform_step_for(step_definition)
         end
@@ -166,7 +165,6 @@ module AcidicJob
             @__acidic_job_execution__.record!(
               step: curr_step,
               action: :errored,
-              timestamp: Time.now,
               exception_class: rescued_error.class.name,
               message: rescued_error.message
             )

--- a/lib/generators/acidic_job/templates/create_acidic_job_tables_migration.rb.erb
+++ b/lib/generators/acidic_job/templates/create_acidic_job_tables_migration.rb.erb
@@ -2,11 +2,11 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
   def change
     create_table :acidic_job_executions, force: true do |t|
       t.string      :idempotency_key, null: false,  index: { unique: true }
-      t.json        :serialized_job, 	null: false,  default: "{}"
+      t.json        :serialized_job, 	null: false
       t.datetime    :last_run_at, 		null: true
       t.datetime    :locked_at, 			null: true
       t.string      :recover_to, 	    null: true
-      t.json        :definition, 			null: true,   default: "{}"
+      t.text        :definition, 			null: true
 
       t.timestamps
     end
@@ -16,7 +16,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.string     :step,      null: false
       t.string     :action,    null: false
       t.datetime   :timestamp, null: false
-      t.json       :data,      null: true,  default: "{}"
+      t.text       :data,      null: true
 
       t.timestamps
     end

--- a/test/combustion/db/schema.rb
+++ b/test/combustion/db/schema.rb
@@ -2,22 +2,22 @@
 
 ActiveRecord::Schema.define do
   create_table :acidic_job_executions, force: true do |t|
-    t.string      :idempotency_key, null: false,  index: { unique: true }
-    t.json        :serialized_job, 	null: false,  default: "{}"
+    t.string      :idempotency_key, null: false, index: { unique: true }
+    t.json        :serialized_job, 	null: false
     t.datetime    :last_run_at,	null: true
     t.datetime    :locked_at,	null: true
     t.string      :recover_to, null: true
-    t.json        :definition,	null: true, default: "{}"
+    t.text        :definition,	null: true
 
     t.timestamps
   end
 
   create_table :acidic_job_entries do |t|
     t.references :execution, null: false, foreign_key: { to_table: :acidic_job_executions, on_delete: :cascade }
-    t.string     :step,      null: false
-    t.string     :action,    null: false
-    t.datetime   :timestamp, null: false
-    t.json       :data,      null: true, default: "{}"
+    t.string :step, null: false
+    t.string :action, null: false
+    t.datetime :timestamp, null: false
+    t.text :data,	null: true
 
     t.timestamps
   end
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define do
 
   create_table :acidic_job_values do |t|
     t.references :execution, null: false, foreign_key: { to_table: :acidic_job_executions, on_delete: :cascade }
-    t.string     :key,       null: false
-    t.text       :value,     null: false
+    t.string :key, null: false
+    t.text :value, null: false
 
     t.timestamps
   end


### PR DESCRIPTION
Building off of #122, this uses the new serializer for `Execution#definition` and `Entry#data`. By using the serializer, we get two key benefits:
1. attempts to use non-primitive values will raise a clear exception early
2. the range of acceptable primitive values is expanded via the enhanced ActiveJob serializer in the gem

We do not use the serializer for `Execution#serialized_job` because it is difficult to check if a payload has already been serialized by ActiveJob, and we have no expectation of an end-user ever supplying arbitrary data to this field.