### PR TITLE
Add automatic retry for serializable transaction failures

### DIFF
--- a/lib/acidic_job.rb
+++ b/lib/acidic_job.rb
@@ -24,6 +24,7 @@ module AcidicJob
   mattr_accessor :connects_to
   mattr_accessor :plugins, default: [ Plugins::TransactionalStep ]
   mattr_accessor :clear_finished_executions_after, default: 1.week
+  mattr_accessor :initialize_workflow_max_retries, default: 3
 
   def instrument(channel, **options, &block)
     ActiveSupport::Notifications.instrument("#{channel}.acidic_job", **options.deep_symbolize_keys, &block)

--- a/lib/acidic_job/errors.rb
+++ b/lib/acidic_job/errors.rb
@@ -119,5 +119,15 @@ module AcidicJob
       "plugin `#{@plugin_name}` failed to call step: #{@step.inspect}"
     end
   end
+
+  class InitializeWorkflowRetriesExhaustedError < Error
+    def initialize(retries)
+      @retries = retries
+    end
+
+    def message
+      "serializable transaction failed after #{@retries} retries"
+    end
+  end
   # rubocop:enable Lint/MissingSuper
 end

--- a/lib/acidic_job/workflow.rb
+++ b/lib/acidic_job/workflow.rb
@@ -29,54 +29,13 @@ module AcidicJob
       end
 
       AcidicJob.instrument(:initialize_workflow, definition: workflow_definition) do
-        transaction_args = case ::ActiveRecord::Base.connection.adapter_name.downcase.to_sym
-          # SQLite doesn't support `serializable` transactions
-        when :sqlite
-            {}
-        else
-            { isolation: :serializable }
-        end
         idempotency_key = Digest::SHA256.hexdigest(JSON.generate([ self.class.name, unique_by ], strict: true))
 
-        @__acidic_job_execution__ = ::ActiveRecord::Base.transaction(**transaction_args) do
-          record = Execution.find_by(idempotency_key: idempotency_key)
-
-          if record.present?
-            # Programs enqueuing multiple jobs with different parameters but the
-            # same idempotency key is a bug.
-            if record.raw_arguments != serialized_job["arguments"]
-              raise ArgumentMismatchError.new(serialized_job["arguments"], record.raw_arguments)
-            end
-
-            if record.definition != workflow_definition
-              raise DefinitionMismatchError.new(workflow_definition, record.definition)
-            end
-
-            # Only acquire a lock if the key is unlocked or its lock has expired
-            # because the original job was long enough ago.
-            # raise "LockedIdempotencyKey" if record.locked_at > Time.current - 2.seconds
-
-            record.update!(
-              last_run_at: Time.current
-            )
-          else
-            starting_point = if workflow_definition.key?("steps")
-              workflow_definition["steps"].keys.first
-            else
-              # TODO: add deprecation warning
-              workflow_definition.keys.first
-            end
-
-            record = Execution.create!(
-              idempotency_key: idempotency_key,
-              serialized_job: serialized_job,
-              definition: workflow_definition,
-              recover_to: starting_point
-            )
-          end
-
-          record
-        end
+        @__acidic_job_execution__ = find_or_create_execution(
+          idempotency_key: idempotency_key,
+          serialized_job: serialized_job,
+          workflow_definition: workflow_definition
+        )
       end
       @__acidic_job_context__ ||= Context.new(@__acidic_job_execution__)
 
@@ -229,6 +188,70 @@ module AcidicJob
       end
 
       catch(:repeat) { plugin_pipeline_callable.call }
+    end
+
+    private def find_or_create_execution(idempotency_key:, serialized_job:, workflow_definition:)
+      retries = 0
+      max_retries = AcidicJob.initialize_workflow_max_retries
+
+      transaction_args = case ::ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+        # SQLite doesn't support `serializable` transactions
+      when :sqlite
+          {}
+      else
+          { isolation: :serializable }
+      end
+
+      begin
+        ::ActiveRecord::Base.transaction(**transaction_args) do
+          record = Execution.find_by(idempotency_key: idempotency_key)
+
+          if record.present?
+            # Programs enqueuing multiple jobs with different parameters but the
+            # same idempotency key is a bug.
+            if record.raw_arguments != serialized_job["arguments"]
+              raise ArgumentMismatchError.new(serialized_job["arguments"], record.raw_arguments)
+            end
+
+            if record.definition != workflow_definition
+              raise DefinitionMismatchError.new(workflow_definition, record.definition)
+            end
+
+            # Only acquire a lock if the key is unlocked or its lock has expired
+            # because the original job was long enough ago.
+            # raise "LockedIdempotencyKey" if record.locked_at > Time.current - 2.seconds
+
+            record.update!(
+              last_run_at: Time.current
+            )
+          else
+            starting_point = if workflow_definition.key?("steps")
+              workflow_definition["steps"].keys.first
+            else
+              # TODO: add deprecation warning
+              workflow_definition.keys.first
+            end
+
+            record = Execution.create!(
+              idempotency_key: idempotency_key,
+              serialized_job: serialized_job,
+              definition: workflow_definition,
+              recover_to: starting_point
+            )
+          end
+
+          record
+        end
+      rescue ActiveRecord::SerializationFailure, ActiveRecord::Deadlocked
+        retries += 1
+        if retries <= max_retries
+          # Exponential backoff: 50ms, 100ms, 200ms, etc.
+          sleep(0.05 * (2 ** (retries - 1)))
+          retry
+        else
+          raise InitializeWorkflowRetriesExhaustedError.new(retries)
+        end
+      end
     end
   end
 end

--- a/test/acidic_job/workflow_errors_test.rb
+++ b/test/acidic_job/workflow_errors_test.rb
@@ -201,14 +201,8 @@ class AcidicJob::WorkflowErrorsTest < ActiveJob::TestCase
   end
 
   test "retries on ActiveRecord::SerializationFailure and succeeds" do
-    attempt_count = 0
-
     class SerializationRetryJob < ActiveJob::Base
       include AcidicJob::Workflow
-
-      cattr_accessor :attempt_count, default: 0
-      cattr_accessor :fail_count, default: 2
-
       def perform
         execute_workflow(unique_by: "serialization-retry-test") do |w|
           w.step :step_1


### PR DESCRIPTION
- Add AcidicJob. initialize_workflow_max_retries config (default: 3)
- Add InitializeWorkflowRetriesExhaustedError
- Extract find_or_create_execution method with built-in retry logic
- Catch ActiveRecord::SerializationFailure and ActiveRecord::Deadlocked
- Implement exponential backoff (50ms, 100ms, 200ms, etc.)

Resolves #91