### PR TITLE
CI: drop Docker Hub dependency (use runner's pre-installed Postgres/MySQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,24 +44,18 @@ jobs:
           - ruby: "3.2"
             gemfile: rails_main
 
-    services:
-      mysql:
-        image: mysql:8.0.31
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-        ports:
-          - 33060:3306
-        options: --health-cmd "mysql -h localhost -e \"select now()\"" --health-interval 1s --health-timeout 5s --health-retries 30
-      postgres:
-        image: postgres:15.1
-        env:
-          POSTGRES_HOST_AUTH_METHOD: "trust"
-        ports:
-          - 55432:5432
-
+    # No Docker service containers: use the database servers pre-installed on the
+    # GitHub-hosted runner instead, so CI never pulls images from Docker Hub
+    # (which was an intermittent source of "Initialize containers" failures).
     env:
       TARGET_DB: ${{ matrix.database }}
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+      # Point at the runner's pre-installed Postgres/MySQL (overrides the
+      # docker-compose defaults in test/dummy/config/database.yml).
+      POSTGRES_PORT: 5432
+      POSTGRES_PASSWORD: postgres
+      MYSQL_PORT: 3306
+      MYSQL_PASSWORD: root
 
     steps:
       - name: Install packages
@@ -75,6 +69,18 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+
+      - name: Start database server
+        run: |
+          case "${{ matrix.database }}" in
+            postgres)
+              sudo systemctl start postgresql
+              sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres';"
+              ;;
+            mysql)
+              sudo systemctl start mysql
+              ;;
+          esac
 
       - name: Setup test database
         run: |

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -7,19 +7,21 @@ default: &default
 default: &default
   adapter: postgresql
   encoding: unicode
-  username: postgres
+  username: <%= ENV.fetch("POSTGRES_USER", "postgres") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD", "") %>
   pool: 20
   host: "127.0.0.1"
-  port: 55432
+  port: <%= ENV.fetch("POSTGRES_PORT", 55432) %>
   gssencmode: disable # https://github.com/ged/ruby-pg/issues/311
 
 <% elsif ENV["TARGET_DB"] == "mysql" %>
 default: &default
   adapter: mysql2
-  username: root
+  username: <%= ENV.fetch("MYSQL_USER", "root") %>
+  password: <%= ENV.fetch("MYSQL_PASSWORD", "") %>
   pool: 20
   host: "127.0.0.1"
-  port: 33060
+  port: <%= ENV.fetch("MYSQL_PORT", 33060) %>
 <% end %>
 
 <% def database_name_from(name); ENV["TARGET_DB"]=="sqlite" ? "db/#{name}-#{ENV['TEST_ENV_NUMBER']}.sqlite3" : name; end %>


### PR DESCRIPTION
## Problem

Every `test` matrix job declared Docker `services:` containers (`mysql:8.0.31`, `postgres:15.1`), so each of the ~40 jobs pulled **two images from Docker Hub** at the "Initialize containers" step. This was an intermittent CI failure source — Docker Hub rate-limits/timeouts (`request canceled while waiting for connection`) failed jobs *before any tests ran* — and wasteful (even sqlite jobs pulled both DB images).

## Change

GitHub-hosted runners ship Postgres and MySQL pre-installed. Start the one the matrix entry needs via `systemctl` and drop the `services:` block entirely — **CI no longer touches Docker Hub**.

- `ci.yml`: remove the `services:` containers; add a "Start database server" step that starts the runner's `postgresql`/`mysql` for the relevant matrix DB (sqlite needs nothing); set env to point at them.
- `database.yml`: now env-driven (`POSTGRES_PORT`/`POSTGRES_PASSWORD`, `MYSQL_PORT`/`MYSQL_PASSWORD`) with the **existing docker-compose values as defaults**, so local development is unchanged; CI overrides to the pre-installed servers (Postgres `5432`, MySQL `3306`).

## Verification

Locally (sqlite): existing tests pass; the `database.yml` ERB renders correctly for all three adapters with the CI env applied (postgres→5432/postgres, mysql→3306/root, sqlite unchanged). The Postgres/MySQL connection to the pre-installed servers can only be exercised on GitHub's runners, so **this needs a CI run to confirm green** — I'll watch it and iterate if the pre-installed auth needs tweaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)