### PR TITLE
Add `retry:` pro plugin (per-step retry policy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ Unlike `transactional:`, which wraps the step body, the consequence runs _after_
 > [!IMPORTANT]
 > The consequence shares the transaction that writes the `succeeded` entry to the `AcidicJob::Execution` record. Because that entry write is *always* part of the transaction, the consequence **must** write to the same database as the `AcidicJob` tables — that is the only way the two writes can be atomic. There is deliberately no option to bind the transaction to a different model or database: a consequence that mutates a record on a _different_ database simply cannot be committed atomically with the workflow's progression, and should instead be modeled as its own idempotent step.
 
+#### Retrying individual steps
+
+Active Job's `retry_on` applies to the whole job. But within a workflow, different steps fail for different reasons — a third-party API call may deserve several backed-off attempts while a local database write does not. The `retry:` option (provided by the `AcidicJob::Plugins::Pro::Retry` plugin) gives a single step its own retry policy:
+
+```ruby
+execute_workflow(unique_by: @order) do |workflow|
+  workflow.step :charge_card, retry: { on: Net::OpenTimeout, attempts: 5, backoff: :exponential }
+  workflow.step :sync_crm,    retry: { attempts: 3, backoff: 2 } # any error, fixed 2s
+  workflow.step :send_receipt
+end
+```
+
+When the step raises a matching error (or any error, if `on:` is omitted), the workflow is re-enqueued with a backoff delay and the step re-runs from scratch — up to `attempts` times. Once the budget is exhausted the error propagates normally, so the job's own `retry_on`/`discard_on` still has the final say. `backoff:` accepts `:exponential` (1, 2, 4, … seconds), `:linear` (1, 2, 3, …), or a fixed number of seconds.
+
+Because a retried step simply runs again from the top, the same idempotency rules apply: a step method must be safe to re-run after a failure.
+
 
 ### Persisted Attributes
 
@@ -404,6 +420,7 @@ class AcidicJobProExample < ActiveJob::Base
       w.step :step_3, compensate: { on: CustomError, with: :compensation }
       w.step :step_4, skip_if: :check?
       w.step :step_5, for_each: :models
+      w.step :step_6, retry: { on: CustomError, attempts: 3, backoff: :exponential }
     end
   end
 
@@ -414,6 +431,7 @@ class AcidicJobProExample < ActiveJob::Base
   def step_3 = # ...
   def step_4 = # ...
   def step_5 = # ...
+  def step_6 = # ...
 
   def conditional?
     # make some IO read to determine if it is OK now to perform the step

--- a/lib/acidic_job/plugins/pro/retry.rb
+++ b/lib/acidic_job/plugins/pro/retry.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module AcidicJob
+  module Plugins
+    module Pro
+      # Retry gives a single step its own retry policy, independent of the job's
+      # global `retry_on`. When the step raises a matching error, the step is
+      # re-enqueued (with backoff) and re-run from scratch, up to `attempts`
+      # times; once the budget is exhausted the error propagates normally (to the
+      # job's `retry_on`/`discard_on` handling).
+      #
+      #   w.step :charge, retry: { on: Net::OpenTimeout, attempts: 5, backoff: :exponential }
+      #   w.step :sync,   retry: { attempts: 3, backoff: 2 } # any error, fixed 2s
+      module Retry
+        extend self
+
+        class InvalidOptionsError < AcidicJob::Error
+          def message
+            "retry: must be a Hash with an Integer `attempts:` (optional `on:` and `backoff:`)"
+          end
+        end
+
+        def keyword
+          :retry
+        end
+
+        # retry: { attempts: 3 }
+        # retry: { on: Error, attempts: 5, backoff: :exponential }
+        # retry: { on: [E1, E2], attempts: 3, backoff: 2 }
+        def validate(input)
+          raise InvalidOptionsError unless input in Hash
+          raise InvalidOptionsError unless input in Hash[attempts: Integer]
+          raise InvalidOptionsError unless input[:attempts] >= 1
+
+          output = { "attempts" => input[:attempts] }
+
+          if input.key?(:on)
+            unless input[:on] in Module | Array[ Module ]
+              raise ArgumentError.new("retry: `on` must be an error class or array of error classes")
+            end
+            output["on"] = Array(input[:on])
+          end
+
+          backoff = input.fetch(:backoff, :exponential)
+          unless backoff in Numeric | :exponential | :linear
+            raise ArgumentError.new("retry: `backoff` must be :exponential, :linear, or a number of seconds")
+          end
+          output["backoff"] = backoff.is_a?(Symbol) ? backoff.to_s : backoff
+
+          output
+        end
+
+        def around_step(context) # &block
+          yield
+        rescue => e
+          options = context.definition
+          triggers = options["on"]
+
+          # Only this plugin's configured error(s) are retried; anything else
+          # propagates untouched (bare `raise` preserves the backtrace).
+          raise if triggers && triggers.none? { |klass| klass === e }
+
+          attempts = options["attempts"]
+          prior_retries = context.entries_for_action(:retrying).for_step(context.current_step).count
+
+          # Budget exhausted — let the error propagate to the job's own handling.
+          raise if prior_retries >= attempts - 1
+
+          wait = backoff_for(options["backoff"], prior_retries)
+
+          context.record!(
+            step: context.current_step,
+            action: :retrying,
+            timestamp: Time.current,
+            attempt: prior_retries + 1,
+            wait: wait,
+            exception_class: e.class.name,
+            message: e.message
+          )
+
+          # Re-enqueue this run with backoff; on the next pass the step re-runs
+          # from scratch (it has no `succeeded` entry yet).
+          context.enqueue_job(wait_until: Time.current + wait)
+          context.halt_workflow!
+        end
+
+        private def backoff_for(strategy, prior_retries)
+          case strategy
+          when "exponential" then 2**prior_retries # 1, 2, 4, 8, ...
+          when "linear"      then prior_retries + 1 # 1, 2, 3, ...
+          else strategy                             # fixed number of seconds
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/pro/retry_test.rb
+++ b/test/pro/retry_test.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "acidic_job/plugins/pro/retry"
+
+RetryFlakyError = Class.new(StandardError) unless defined?(RetryFlakyError)
+RetryOtherError = Class.new(StandardError) unless defined?(RetryOtherError)
+
+# Register at load time (not in `before_setup`) so the plugin is active during
+# `test_simulation`'s callstack capture, which runs when the class is defined.
+unless AcidicJob.plugins.include?(AcidicJob::Plugins::Pro::Retry)
+  AcidicJob.plugins << AcidicJob::Plugins::Pro::Retry
+end
+
+module Pro
+  class RetryTest < ActiveJob::TestCase
+    # ============================================
+    # Validation
+    # ============================================
+
+    test "validate accepts attempts only" do
+      assert_equal({ "attempts" => 3, "backoff" => "exponential" }, AcidicJob::Plugins::Pro::Retry.validate(attempts: 3))
+    end
+
+    test "validate accepts on + attempts + backoff" do
+      assert_equal(
+        { "attempts" => 5, "on" => [ RetryFlakyError ], "backoff" => "linear" },
+        AcidicJob::Plugins::Pro::Retry.validate(on: RetryFlakyError, attempts: 5, backoff: :linear)
+      )
+    end
+
+    test "validate accepts a fixed numeric backoff" do
+      assert_equal({ "attempts" => 2, "backoff" => 2 }, AcidicJob::Plugins::Pro::Retry.validate(attempts: 2, backoff: 2))
+    end
+
+    test "validate rejects a non-hash" do
+      assert_raises(AcidicJob::Plugins::Pro::Retry::InvalidOptionsError) { AcidicJob::Plugins::Pro::Retry.validate(:nope) }
+    end
+
+    test "validate rejects a missing attempts" do
+      assert_raises(AcidicJob::Plugins::Pro::Retry::InvalidOptionsError) { AcidicJob::Plugins::Pro::Retry.validate(on: RetryFlakyError) }
+    end
+
+    test "validate rejects a bad backoff" do
+      assert_raises(ArgumentError) { AcidicJob::Plugins::Pro::Retry.validate(attempts: 3, backoff: :nope) }
+    end
+
+    # ============================================
+    # Behavior
+    # ============================================
+
+    class TransientJob < ActiveJob::Base
+      include AcidicJob::Workflow
+
+      def perform
+        execute_workflow(unique_by: job_id) do |w|
+          w.step :flaky, retry: { on: RetryFlakyError, attempts: 3, backoff: 1 }
+          w.step :finish
+        end
+      end
+
+      def flaky
+        # fails on the first two executions, succeeds on the third
+        raise RetryFlakyError if executions < 3
+
+        ChaoticJob.log_to_journal!(:flaky_ok)
+      end
+
+      def finish
+        ChaoticJob.log_to_journal!(:finished)
+      end
+    end
+
+    test "retries a matching error with backoff and eventually succeeds" do
+      TransientJob.perform_later
+      # the reschedules are future-dated, but the performer drains them regardless
+      perform_all_jobs
+
+      assert_only_one_execution_that_it_is_finished_and_each_step_only_succeeds_once
+      execution = AcidicJob::Execution.first
+
+      assert_equal(
+        [
+          %w[flaky started],
+          %w[flaky retry/retrying],
+          %w[flaky halted],
+          %w[flaky started],
+          %w[flaky retry/retrying],
+          %w[flaky halted],
+          %w[flaky started],
+          %w[flaky succeeded],
+          %w[finish started],
+          %w[finish succeeded]
+        ],
+        execution.entries.ordered.pluck(:step, :action)
+      )
+
+      assert_equal 2, execution.entries.for_action("retry/retrying").count
+      assert_equal [ :flaky_ok, :finished ], ChaoticJob::Journal.entries
+    end
+
+    class NonMatchingJob < ActiveJob::Base
+      include AcidicJob::Workflow
+
+      def perform
+        execute_workflow(unique_by: job_id) do |w|
+          w.step :boom, retry: { on: RetryFlakyError, attempts: 3 }
+        end
+      end
+
+      def boom
+        raise RetryOtherError, "not retryable"
+      end
+    end
+
+    test "does not retry a non-matching error" do
+      assert_raises(RetryOtherError) { NonMatchingJob.perform_now }
+
+      execution = AcidicJob::Execution.first
+      assert_not execution.entries.for_action("retry/retrying").exists?
+      assert execution.entries.for_step("boom").for_action("errored").exists?
+    end
+
+    class ExhaustingJob < ActiveJob::Base
+      include AcidicJob::Workflow
+
+      def perform
+        execute_workflow(unique_by: job_id) do |w|
+          w.step :always_fails, retry: { on: RetryFlakyError, attempts: 3, backoff: 1 }
+        end
+      end
+
+      def always_fails
+        raise RetryFlakyError, "permanent"
+      end
+    end
+
+    test "propagates the error once the retry budget is exhausted" do
+      ExhaustingJob.perform_later
+      assert_raises(RetryFlakyError) { perform_all_jobs }
+
+      execution = AcidicJob::Execution.first
+      # attempts: 3 -> 2 reschedules, then the third failure propagates
+      assert_equal 2, execution.entries.for_action("retry/retrying").count
+      assert execution.entries.for_step("always_fails").for_action("errored").exists?
+      assert_not execution.entries.for_step("always_fails").for_action("succeeded").exists?
+    end
+
+    class BackoffJob < ActiveJob::Base
+      include AcidicJob::Workflow
+
+      def perform
+        execute_workflow(unique_by: job_id) do |w|
+          w.step :flaky, retry: { on: RetryFlakyError, attempts: 4, backoff: :exponential }
+        end
+      end
+
+      def flaky
+        raise RetryFlakyError if executions < 4
+
+        ChaoticJob.log_to_journal!(:ok)
+      end
+    end
+
+    test "records exponential backoff waits per attempt" do
+      BackoffJob.perform_later
+      perform_all_jobs
+
+      execution = AcidicJob::Execution.first
+      waits = execution.entries.for_action("retry/retrying").ordered.map { |e| e.data[:wait] }
+      assert_equal [ 1, 2, 4 ], waits
+    end
+
+    # ============================================
+    # Chaos
+    # ============================================
+
+    class SimJob < ActiveJob::Base
+      include AcidicJob::Workflow
+
+      def perform
+        execute_workflow(unique_by: job_id) do |w|
+          w.step :flaky, retry: { on: RetryFlakyError, attempts: 5, backoff: 1 }
+          w.step :finish
+        end
+      end
+
+      def flaky
+        raise RetryFlakyError if executions < 2
+
+        ChaoticJob.log_to_journal!(:flaky_ok)
+      end
+
+      def finish
+        ChaoticJob.log_to_journal!(:finished)
+      end
+    end
+
+    test_simulation(SimJob.new) do |_scenario|
+      assert_only_one_execution_that_it_is_finished_and_each_step_only_succeeds_once
+      assert_includes ChaoticJob::Journal.entries, :flaky_ok
+      assert_includes ChaoticJob::Journal.entries, :finished
+    end
+  end
+end


### PR DESCRIPTION
First of the new plugin proposals, on its own branch for independent review.

## What

A `retry:` step option giving a single step its own retry policy, independent of the job-global `retry_on`:

```ruby
w.step :charge_card, retry: { on: Net::OpenTimeout, attempts: 5, backoff: :exponential }
w.step :sync_crm,    retry: { attempts: 3, backoff: 2 } # any error, fixed 2s
```

## Why

Different steps in a workflow fail for different reasons — a flaky third-party call deserves several backed-off attempts; a local DB write doesn't. `retry_on` can't express that per-step; this can.

## How it works

On a matching error (or any error when `on:` is omitted), the step is re-enqueued with a backoff delay and re-run from scratch (it has no `succeeded` entry yet), up to `attempts` times. Once the budget is exhausted the error propagates normally, so the job's own `retry_on`/`discard_on` still has the final say. Non-matching errors re-raise immediately with their original backtrace. `backoff:` accepts `:exponential` / `:linear` / a fixed number of seconds. Implemented purely via the existing `around_step` + halt/re-enqueue mechanics — no core changes.

## Tests

`test/pro/retry_test.rb`: validation, transient-then-success, non-matching propagation, budget exhaustion, recorded backoff waits, and a `test_simulation`. Full suite green (421 runs); coverage gate passes (94.0% line / 79.4% branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)