### PR TITLE
Add `await_signal:` pro plugin (event-driven gates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,39 @@ Unlike `transactional:`, which wraps the step body, the consequence runs _after_
 > [!IMPORTANT]
 > The consequence shares the transaction that writes the `succeeded` entry to the `AcidicJob::Execution` record. Because that entry write is *always* part of the transaction, the consequence **must** write to the same database as the `AcidicJob` tables — that is the only way the two writes can be atomic. There is deliberately no option to bind the transaction to a different model or database: a consequence that mutates a record on a _different_ database simply cannot be committed atomically with the workflow's progression, and should instead be modeled as its own idempotent step.
 
+#### Waiting for an external signal
+
+Some workflows have to pause until something *outside* the job happens — a webhook lands, an admin approves, a third party finishes. The `await_signal:` option (provided by the `AcidicJob::Plugins::Pro::AwaitSignal` plugin) gates a step on a condition method and, if it isn't satisfied yet, halts the workflow:
+
+```ruby
+class OnboardJob < ActiveJob::Base
+  include AcidicJob::Workflow
+
+  def perform(user_id)
+    @user = User.find(user_id)
+    execute_workflow(unique_by: user_id) do |workflow|
+      workflow.step :await_kyc, await_signal: :kyc_approved?
+      workflow.step :activate_account
+    end
+  end
+
+  def kyc_approved? = @user.reload.kyc_approved?
+  # ...
+end
+```
+
+When `kyc_approved?` is false the workflow halts on the `await_kyc` step. It resumes when something re-enqueues the job with the **same `unique_by`** — typically an event handler:
+
+```ruby
+# in your KYC webhook controller
+OnboardJob.perform_later(user.id)
+```
+
+On resume the condition is re-checked; if it's now true the workflow proceeds, otherwise it simply halts again. This makes `await_signal:` the natural fit for human-in-the-loop gates and webhook-driven workflows.
+
+> [!NOTE]
+> Unlike `check: { every:, until: }`, which polls on a timer, `await_signal:` does **not** reschedule itself — it waits to be re-triggered by an external event. Use `check:` when time will eventually satisfy the condition; use `await_signal:` when an outside actor will. (And remember to key `unique_by` on a stable domain id, not `job_id`, so the re-trigger resumes the same execution.)
+
 
 ### Persisted Attributes
 
@@ -404,6 +437,7 @@ class AcidicJobProExample < ActiveJob::Base
       w.step :step_3, compensate: { on: CustomError, with: :compensation }
       w.step :step_4, skip_if: :check?
       w.step :step_5, for_each: :models
+      w.step :step_6, await_signal: :ready?
     end
   end
 

--- a/lib/acidic_job/plugins/pro/await_signal.rb
+++ b/lib/acidic_job/plugins/pro/await_signal.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module AcidicJob
+  module Plugins
+    module Pro
+      # AwaitSignal pauses a step until an external signal arrives. The named
+      # method is checked each time the step runs: if it returns truthy the step
+      # proceeds; otherwise the workflow halts and waits. Unlike `check:` (which
+      # re-schedules itself on a timer to poll), AwaitSignal does NOT reschedule
+      # — it relies on an external event re-enqueuing the job to resume it.
+      #
+      #   w.step :await_approval, await_signal: :approved?
+      #   w.step :activate
+      #
+      # The workflow resumes when something performs the job again with the SAME
+      # `unique_by` (e.g. a webhook handler: `OnboardJob.perform_later(user_id)`).
+      # This makes it the natural fit for human-in-the-loop gates and
+      # event/webhook-driven workflows. (Because there is no self-reschedule, the
+      # caller is responsible for re-triggering when the awaited event occurs.)
+      module AwaitSignal
+        extend self
+
+        class InvalidMethodError < AcidicJob::Error
+          def message
+            "await_signal: must be a 0-arity method"
+          end
+        end
+
+        def keyword
+          :await_signal
+        end
+
+        def validate(input)
+          raise ArgumentError.new("await_signal: value must be a method name") unless input in Symbol | String
+
+          input.to_s
+        end
+
+        def around_step(context) # &block
+          signal = context.definition
+          signal_method = context.resolve_method(signal)
+          raise InvalidMethodError unless signal_method.arity.zero?
+
+          if signal_method.call
+            yield
+          else
+            context.record!(step: context.current_step, action: :awaiting, timestamp: Time.current)
+            context.halt_workflow!
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/pro/await_signal_test.rb
+++ b/test/pro/await_signal_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "acidic_job/plugins/pro/await_signal"
+
+unless AcidicJob.plugins.include?(AcidicJob::Plugins::Pro::AwaitSignal)
+  AcidicJob.plugins << AcidicJob::Plugins::Pro::AwaitSignal
+end
+
+module Pro
+  class AwaitSignalTest < ActiveJob::TestCase
+    def before_setup
+      ChaoticJob.switch_off!
+      super
+    end
+
+    # ============================================
+    # Validation
+    # ============================================
+
+    test "validate accepts a symbol and normalizes to a string" do
+      assert_equal "approved?", AcidicJob::Plugins::Pro::AwaitSignal.validate(:approved?)
+    end
+
+    test "validate rejects a non-method-name value" do
+      error = assert_raises(ArgumentError) { AcidicJob::Plugins::Pro::AwaitSignal.validate(every: 1) }
+      assert_match(/must be a method name/, error.message)
+    end
+
+    test "fails fast when the signal method is undefined" do
+      job_class = Class.new(ActiveJob::Base) do
+        include AcidicJob::Workflow
+
+        def perform
+          execute_workflow(unique_by: job_id) do |w|
+            w.step :gate, await_signal: :nonexistent
+          end
+        end
+
+        def gate
+          nil
+        end
+      end
+
+      assert_raises(AcidicJob::UndefinedMethodError) { job_class.perform_now }
+    end
+
+    # ============================================
+    # Behavior
+    # ============================================
+
+    class Job < ActiveJob::Base
+      include AcidicJob::Workflow
+
+      def perform(id)
+        execute_workflow(unique_by: id) do |w|
+          w.step :await_approval, await_signal: :approved?
+          w.step :activate
+        end
+      end
+
+      def approved?
+        ChaoticJob.switch_on?
+      end
+
+      def await_approval
+        ChaoticJob.log_to_journal!(:approval_seen)
+      end
+
+      def activate
+        ChaoticJob.log_to_journal!(:activated)
+      end
+    end
+
+    test "proceeds immediately when the signal is already present" do
+      ChaoticJob.switch_on!
+
+      Job.perform_later("order-1")
+      perform_all_jobs
+
+      assert_only_one_execution_that_it_is_finished_and_each_step_only_succeeds_once
+      assert_equal [ :approval_seen, :activated ], ChaoticJob::Journal.entries
+    end
+
+    test "halts (without rescheduling) until the signal arrives, then resumes on re-trigger" do
+      Job.perform_later("order-1")
+      perform_all_jobs
+
+      # signal absent: halted on the gate, body not run, and NOTHING re-enqueued
+      execution = AcidicJob::Execution.first
+      assert_equal "await_approval", execution.recover_to
+      assert_equal 0, ChaoticJob.journal_size
+      assert_equal 0, enqueued_jobs.size
+      assert_equal(
+        [ %w[await_approval started], %w[await_approval await_signal/awaiting], %w[await_approval halted] ],
+        execution.entries.ordered.pluck(:step, :action)
+      )
+
+      # external event arrives: flip the signal and re-trigger the same unique_by
+      ChaoticJob.switch_on!
+      Job.perform_later("order-1")
+      perform_all_jobs
+
+      assert_only_one_execution_that_it_is_finished_and_each_step_only_succeeds_once
+      assert_equal [ :approval_seen, :activated ], ChaoticJob::Journal.entries
+    end
+
+    test "re-halts when re-triggered while the signal is still absent" do
+      Job.perform_later("order-1")
+      perform_all_jobs
+
+      # a premature re-trigger (signal still off) just halts again
+      Job.perform_later("order-1")
+      perform_all_jobs
+
+      execution = AcidicJob::Execution.first
+      assert_equal "await_approval", execution.recover_to
+      assert_equal 2, execution.entries.for_action("await_signal/awaiting").count
+      assert_equal 0, ChaoticJob.journal_size
+    end
+  end
+end


### PR DESCRIPTION
A pure plugin (no new infrastructure) for pausing a workflow until an external event occurs.

## What

```ruby
w.step :await_approval, await_signal: :approved?
w.step :activate
```

The named method is checked each time the step runs. If truthy, the step proceeds; otherwise the workflow **halts and waits**. It resumes when something re-enqueues the job with the same `unique_by` — e.g. a webhook handler doing `OnboardJob.perform_later(user_id)`.

## Why / how it differs from `check:`

`check: { every:, until: }` polls on a timer (good when *time* eventually satisfies the condition). `await_signal:` does **not** reschedule — it waits to be re-triggered by an outside actor (good for webhooks, human-in-the-loop approvals). It formalizes the event-driven resume pattern: halt, and let the external event drive the workflow forward.

## Tests

`test/pro/await_signal_test.rb`: validation, fail-fast on undefined method, proceeds-immediately, halt-then-resume-on-re-trigger (asserting nothing is self-enqueued while waiting), and re-halt when re-triggered before the signal arrives. Full suite green (405 runs); coverage gate passes.

---

Note: this is one of four follow-on plugin ideas. The other three — `lock:`, `throttle:`, `circuit:` — all need *cross-execution* shared state, which the gem has no home for yet; I'm writing up that design separately rather than bolting on an ad-hoc store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)