### PR TITLE
CI: raise test step timeout from 2 to 5 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run the tests
         run: bin/rails test
-        timeout-minutes: 2
+        timeout-minutes: 5
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

`test (3.3, rails_7_2, mysql)` failed on #146 — but it's a **flaky timeout, not a test failure**. The job reached `# Running:` and was killed by `timeout-minutes: 2`. Every other check (43/44) passed, but the mysql jobs now run in 53s–**2m13s** — right at the 2-minute budget.

The suite has grown substantially (pro plugins + `commit:` consequences + the resilience hardening + serializer tests, ~399 tests), and mysql is the slowest adapter, so a slightly slow runner intermittently crosses 2 minutes.

## Fix

Raise the "Run the tests" step `timeout-minutes` from 2 → 5. That's comfortable headroom over the ~1–2 min real runtime, while still catching a genuine hang long before the job's overall limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)